### PR TITLE
Add LastModified to FtpFile

### DIFF
--- a/Ark.Tools.ResourceWatcher.WorkerHost.Ftp/FtpFile.cs
+++ b/Ark.Tools.ResourceWatcher.WorkerHost.Ftp/FtpFile.cs
@@ -15,6 +15,8 @@ namespace Ark.Tools.ResourceWatcher.WorkerHost.Ftp
 
         public Instant RetrievedAt { get; internal set; }
 
+        public LocalDateTime? LastModified { get; internal set; }
+
         public string? CheckSum { get; internal set; }
 
         public TPayload? ParsedData { get; internal set; }

--- a/Ark.Tools.ResourceWatcher.WorkerHost.Ftp/FtpWorkerHost.cs
+++ b/Ark.Tools.ResourceWatcher.WorkerHost.Ftp/FtpWorkerHost.cs
@@ -118,6 +118,7 @@ namespace Ark.Tools.ResourceWatcher.WorkerHost.Ftp
                 {
                     CheckSum = checksum,
                     RetrievedAt = SystemClock.Instance.GetCurrentInstant(),
+                    LastModified = lastState?.Modified,
                     ParsedData = _parser.Parse(metadata, contents)
                 };
 


### PR DESCRIPTION
For FtpWorkers the worker the FtpFile currently has,
```
public class FtpFile<TPayLoad>
{
    public FtpMetadata Metadata { get; set; } details of the file on the ftp server
    public Instant RetrievdAt { get; set; } instant the file is retrieved
    public string CheckSum { get; set; } computed based on the file contents
    public TPayLoad ParsedData { get; set; } defined in the worker
}

public class FtpMetadata
{
    internal FtpMetadata(FtpEntry entry)
    {
        Entry = entry;
        ResourceId = entry.FullPath;
        Modified = LocalDateTime.FromDateTime(entry.Modified);
        ModifiedSources = null;
    }

    public FtpEntry Entry { get; }
    public LocalDateTime Modified { get; }
    public Dictionary<string, LocalDateTime>? ModifiedSources { get; }
    public string ResourceId { get; }
    public object Extensions => new { Entry.Name, Entry.Size };
}
```
The idea is to add LastModified to the FtpFile class where LastModified = laststate.Modified.

EntsoE SFTP files have a column which is the UpdateTime for each row in the file. Adding LastModified enables filtering of the data to write. The data to write would be rows with UpdateTime greater than LastModified.
