### PR TITLE
feat: add support for IAsyncContext

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,3 +20,9 @@ services:
     environment:
       ACCEPT_EULA: Y
       MSSQL_SA_PASSWORD: ArkSpecFlow123Stella!
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    restart: unless-stopped
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db

--- a/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/AuditContext.cs
+++ b/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/AuditContext.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace Ark.Reference.Common.Services.Audit
 {
     public class AuditContext<TAuditKind>
-        where TAuditKind : struct, IConvertible
+        where TAuditKind : struct, Enum
     {
         private readonly Logger _logger;
         private readonly IDbConnection _dbConnection;

--- a/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/Dto/AuditDto.cs
+++ b/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/Dto/AuditDto.cs
@@ -4,7 +4,7 @@ using System;
 namespace Ark.Reference.Common.Services.Audit
 {
     public class AuditDto<TAuditKind>
-        where TAuditKind : struct, IConvertible
+        where TAuditKind : struct, Enum
     {
         public Guid AuditId { get; set; }
         public string UserId { get; set; }

--- a/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/Dto/Queries/AuditQueryDto.cs
+++ b/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/Dto/Queries/AuditQueryDto.cs
@@ -7,7 +7,7 @@ namespace Ark.Reference.Common.Services.Audit
     public static class AuditQueryDto
     {
         public class V1<TAuditKind>
-            where TAuditKind : struct, IConvertible
+            where TAuditKind : struct, Enum
         {
             public Guid[] AuditIds { get; set; }
             public string[] Users { get; set; }

--- a/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/IAuditDataContext.cs
+++ b/Ark.ReferenceProject/Ark.Reference.Common/Services/Audit/IAuditDataContext.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace Ark.Reference.Common.Services.Audit
 {
-    public interface IAuditDataContext<TAuditKind> : IContext, IDisposable
-            where TAuditKind : struct, IConvertible
+    public interface IAuditDataContext<TAuditKind> : IAsyncContext
+            where TAuditKind : struct, Enum
     {
         #region Audit
         Task<(IEnumerable<AuditDto<TAuditKind>> records, int totalCount)> ReadAuditByFilterAsync(

--- a/Ark.ReferenceProject/Ark.Reference.Common/packages.lock.json
+++ b/Ark.ReferenceProject/Ark.Reference.Common/packages.lock.json
@@ -231,8 +231,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w=="
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
       "Microsoft.CodeAnalysis.NetAnalyzers": {
         "type": "Transitive",
@@ -1241,6 +1241,14 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Linq.Async": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
       "System.Linq.Expressions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1821,6 +1829,7 @@
           "Microsoft.CodeAnalysis.NetAnalyzers": "[8.0.0, )",
           "NodaTime": "[3.1.11, )",
           "Polly": "[8.4.1, )",
+          "System.Linq.Async": "[6.0.1, )",
           "System.Reactive": "[6.0.1, )",
           "morelinq": "[4.3.0, )"
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.API/packages.lock.json
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.API/packages.lock.json
@@ -229,8 +229,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w=="
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
       "Microsoft.CodeAnalysis.NetAnalyzers": {
         "type": "Transitive",
@@ -1239,6 +1239,14 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Linq.Async": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
       "System.Linq.Expressions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1841,6 +1849,7 @@
           "Microsoft.CodeAnalysis.NetAnalyzers": "[8.0.0, )",
           "NodaTime": "[3.1.11, )",
           "Polly": "[8.4.1, )",
+          "System.Linq.Async": "[6.0.1, )",
           "System.Reactive": "[6.0.1, )",
           "morelinq": "[4.3.0, )"
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Config/ApiHostConfig.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Config/ApiHostConfig.cs
@@ -1,9 +1,12 @@
 ﻿using Ark.Reference.Common;
 using Ark.Reference.Common.Services.FileStorageService;
+using Ark.Tools.Outbox.SqlServer;
+using Ark.Tools.Sql;
 
 using Microsoft.Extensions.Configuration;
 
 using System;
+using System.Data;
 
 namespace Ark.Reference.Core.Application.Config
 {
@@ -34,12 +37,16 @@ namespace Ark.Reference.Core.Application.Config
         string IRebusBusConfig.AsbConnectionString => RebusBusConfig_AsbConnectionString;
         string IRebusBusConfig.RequestQueue => RebusBusConfig_RequestQueue;
         string IRebusBusConfig.StorageConnectionString => RebusBusConfig_StorageConnectionString;
-        string ICoreDataContextConfig.SQLConnectionString => CoreDataContextConfig_SQLConnectionString;
+
+        string ISqlContextConfig.ConnectionString => CoreDataContextConfig_SQLConnectionString;
 
         string ICoreConfig.Environment => CoreConfig_Environment;
 
         string IFileStorageServiceConfig.StorageAccount => FileServiceStorageAccount;
         string IFileStorageServiceConfig.StoragePrefix => FileServiceStoragePrefix;
+
+
+        IsolationLevel? ISqlContextConfig.IsolationLevel => null;
     }
 
     public static class Ex

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Config/ICoreDataContextConfig.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Config/ICoreDataContextConfig.cs
@@ -1,9 +1,9 @@
 ﻿using Ark.Tools.Outbox.SqlServer;
+using Ark.Tools.Sql;
 
 namespace Ark.Reference.Core.Application.Config
 {
-    public interface ICoreDataContextConfig : IOutboxContextSqlConfig
+    public interface ICoreDataContextConfig : IOutboxContextSqlConfig, ISqlContextConfig
     {
-        public string SQLConnectionString { get; }
     }
 }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/DAL/CoreDataContextFactory.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/DAL/CoreDataContextFactory.cs
@@ -7,48 +7,42 @@ using NodaTime;
 
 using System.Data.Common;
 using System.Security.Claims;
+using Ark.Tools.Core;
+using System.Threading.Tasks;
+using System.Threading;
+using Ark.Tools.Outbox;
 
 namespace Ark.Reference.Core.Application.DAL
 {
-    public sealed class CoreDataContextFactory
+    public interface ICoreDataContextFactory : IAsyncContextFactory<ICoreDataContext> { }
+    public sealed class CoreDataContextFactory : AbstractSqlAsyncContextFactory<CoreDataContext_Sql, CoreDataSql>, ICoreDataContextFactory, IOutboxAsyncContextFactory
     {
         private readonly ICoreDataContextConfig _config;
-        private readonly IDbConnectionManager _connectionManager;
         private readonly IClock _clock;
 
         private readonly IContextProvider<ClaimsPrincipal> _userContext;
 
         public CoreDataContextFactory(ICoreDataContextConfig config, IDbConnectionManager connectionManager, IClock clock, IContextProvider<ClaimsPrincipal> userContext)
+            : base(connectionManager, config)
         {
             _config = config;
-            _connectionManager = connectionManager;
             _clock = clock;
             _userContext = userContext;
         }
 
-        public ICoreDataContext Get(bool readOnly = false)
+        protected override CoreDataContext_Sql CreateContext(DbTransaction transaction)
         {
-            DbConnection conn = null;
-            try
-            {
-                var cs = _config.SQLConnectionString;
-                if (!cs.EndsWith(';')) cs += ";";
-                if (readOnly) cs += "ApplicationIntent=ReadOnly;";
+            return new CoreDataContext_Sql(transaction, _config, _clock, _userContext);
+        }
 
-                conn = _connectionManager.Get(cs);
-                return new CoreDataContext_Sql(conn, _config, _clock, _userContext,
-                    // this is 'risk avoidance'.
-                    // ReadCommitted, even when READ_COMMITTED_SNAPSHOT_ISOLATION is enabled, doesn't guarantee READ consistency between multiple statements
-                    // Transaction may commit in the middle and new data is available.
-                    // RCSI only avoid read locks if a record is UPDATED but not COMMITED returning the initial version.
-                    // It's debetable we should use SNAPSHOT also for Write transactions ...
-                    readOnly ? System.Data.IsolationLevel.Snapshot : System.Data.IsolationLevel.ReadCommitted);
-            }
-            catch
-            {
-                conn?.Dispose();
-                throw;
-            }
+        async Task<ICoreDataContext> IAsyncContextFactory<ICoreDataContext>.CreateAsync(CancellationToken ctk)
+        {
+            return await base.CreateAsync(ctk);
+        }
+
+        async Task<IOutboxAsyncContext> IOutboxAsyncContextFactory.CreateAsync(CancellationToken ctk)
+        {
+            return await base.CreateAsync(ctk);
         }
     }
 

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/DAL/CoreDataContext_Sql.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/DAL/CoreDataContext_Sql.cs
@@ -15,7 +15,7 @@ using System.Security.Claims;
 namespace Ark.Reference.Core.Application.DAL
 {
 
-    public partial class CoreDataContext_Sql : AbstractSqlContextWithOutbox<CoreDataSql>, ICoreDataContext
+    public partial class CoreDataContext_Sql : AbstractSqlAsyncContextWithOutbox<CoreDataSql>, ICoreDataContext
     {
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
         private readonly IClock _clock;
@@ -23,12 +23,11 @@ namespace Ark.Reference.Core.Application.DAL
         //private readonly int _longRunningCommandTimeout = Convert.ToInt32(TimeSpan.FromMinutes(5).TotalSeconds);
         private readonly AuditContext<AuditKind> _auditContext;
 
-        internal CoreDataContext_Sql(DbConnection connection,
+        internal CoreDataContext_Sql(DbTransaction transaction,
                                     IOutboxContextSqlConfig config,
                                     IClock clock,
-                                    IContextProvider<ClaimsPrincipal> _userContext,
-                                    System.Data.IsolationLevel isolationLevel = System.Data.IsolationLevel.ReadCommitted)
-            : base(connection, config, isolationLevel)
+                                    IContextProvider<ClaimsPrincipal> _userContext)
+            : base(transaction, config)
         {
             _clock = clock;
             this._userContext = _userContext;

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/DAL/ICoreDataContext.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/DAL/ICoreDataContext.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Ark.Reference.Core.Application.DAL
 {
-    public interface ICoreDataContext : IOutboxContext, IContext, IDisposable, IAuditDataContext<AuditKind>
+    public interface ICoreDataContext : IOutboxAsyncContext, IAsyncContext, IAuditDataContext<AuditKind>
     {
         #region Ping
         Task<Ping.V1.Output> ReadPingByIdAsync(

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Audit_GetChangesQueryHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Audit_GetChangesQueryHandler.cs
@@ -19,9 +19,9 @@ namespace Ark.Reference.Core.Application.Handlers.Queries
 {
     public class Audit_GetChangesQueryHandler : IQueryHandler<Audit_GetChangesQuery.V1, IAuditRecordReturn<IAuditEntity>>
     {
-        private readonly Func<ICoreDataContext> _dataContext;
+        private readonly ICoreDataContextFactory _dataContext;
 
-        public Audit_GetChangesQueryHandler(Func<ICoreDataContext> dataContext)
+        public Audit_GetChangesQueryHandler(ICoreDataContextFactory dataContext)
         {
             _dataContext = dataContext;
         }
@@ -33,7 +33,7 @@ namespace Ark.Reference.Core.Application.Handlers.Queries
 
         public async Task<IAuditRecordReturn<IAuditEntity>> ExecuteAsync(Audit_GetChangesQuery.V1 query, CancellationToken ctk = default)
         {
-            using var ctx = _dataContext();
+            await using var ctx = await _dataContext.CreateAsync(ctk);
 
             var (records, count) = await ctx.ReadAuditByFilterAsync(new Audit_GetQuery.V1 { AuditIds = [query.AuditId] }, ctk);
 

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Audit_GetQueryHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Audit_GetQueryHandler.cs
@@ -15,9 +15,9 @@ namespace Ark.Reference.Core.Application.Handlers.Queries
 {
     internal class Audit_GetQueryHandler : IQueryHandler<Audit_GetQuery.V1, PagedResult<AuditDto<AuditKind>>>
     {
-        private readonly Func<ICoreDataContext> _dataContext;
+        private readonly ICoreDataContextFactory _dataContext;
 
-        public Audit_GetQueryHandler(Func<ICoreDataContext> dataContext)
+        public Audit_GetQueryHandler(ICoreDataContextFactory dataContext)
         {
             _dataContext = dataContext;
         }
@@ -29,7 +29,7 @@ namespace Ark.Reference.Core.Application.Handlers.Queries
 
         public async Task<PagedResult<AuditDto<AuditKind>>> ExecuteAsync(Audit_GetQuery.V1 query, CancellationToken ctk = default)
         {
-            using var ctx = _dataContext();
+            await using var ctx = await _dataContext.CreateAsync(ctk);
 
             var (records, count) = await ctx.ReadAuditByFilterAsync(query, ctk: ctk);
 

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Audit_GetUsersQueryHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Audit_GetUsersQueryHandler.cs
@@ -12,9 +12,9 @@ namespace Ark.Reference.Core.Application.Handlers.Queries
 {
     internal class Audit_GetUsersQueryHandler : IQueryHandler<Audit_GetUsersQuery.V1, IEnumerable<string>>
     {
-        private readonly Func<ICoreDataContext> _dataContext;
+        private readonly ICoreDataContextFactory _dataContext;
 
-        public Audit_GetUsersQueryHandler(Func<ICoreDataContext> dataContext)
+        public Audit_GetUsersQueryHandler(ICoreDataContextFactory dataContext)
         {
             _dataContext = dataContext;
         }
@@ -26,7 +26,7 @@ namespace Ark.Reference.Core.Application.Handlers.Queries
 
         public async Task<IEnumerable<string>> ExecuteAsync(Audit_GetUsersQuery.V1 query, CancellationToken ctk = default)
         {
-            using var ctx = _dataContext();
+            await using var ctx = await _dataContext.CreateAsync(ctk);
             return await ctx.ReadAuditUsersAsync(ctk: ctk);
         }
     }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Ping_GetByFiltersHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Ping_GetByFiltersHandler.cs
@@ -16,9 +16,9 @@ namespace Core.Services.Application.Handlers.Queries
 {
     public class Ping_GetByFiltersHandler : IQueryHandler<Ping_GetByFiltersQuery.V1, PagedResult<Ping.V1.Output>>
     {
-        private readonly Func<ICoreDataContext> _coreDataContext;
+        private readonly ICoreDataContextFactory _coreDataContext;
 
-        public Ping_GetByFiltersHandler(Func<ICoreDataContext> coreDataContext)
+        public Ping_GetByFiltersHandler(ICoreDataContextFactory coreDataContext)
         {
             EnsureArg.IsNotNull(coreDataContext, nameof(coreDataContext));
 
@@ -34,7 +34,7 @@ namespace Core.Services.Application.Handlers.Queries
         {
             EnsureArg.IsNotNull(query, nameof(query));
 
-            using var ctx = _coreDataContext();
+            await using var ctx = await _coreDataContext.CreateAsync(ctk);
 
             var (data, count) = await ctx.ReadPingByFiltersAsync(query, ctk);
 

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Ping_GetByIdHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Queries/Ping_GetByIdHandler.cs
@@ -16,9 +16,9 @@ namespace Core.Services.Application.Handlers.Queries
 {
     public class Ping_GetIdHandler : IQueryHandler<Ping_GetByIdQuery.V1, Ping.V1.Output>
     {
-        private readonly Func<ICoreDataContext> _coreDataContext;
+        private readonly ICoreDataContextFactory _coreDataContext;
 
-        public Ping_GetIdHandler(Func<ICoreDataContext> coreDataContext)
+        public Ping_GetIdHandler(ICoreDataContextFactory coreDataContext)
         {
             EnsureArg.IsNotNull(coreDataContext, nameof(coreDataContext));
 
@@ -34,7 +34,7 @@ namespace Core.Services.Application.Handlers.Queries
         {
             EnsureArg.IsNotNull(query, nameof(query));
 
-            using var ctx = _coreDataContext();
+            await using var ctx = await _coreDataContext.CreateAsync(ctk);
 
             var entity = await ctx.ReadPingByIdAsync(query.Id, ctk);
 

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_CreateAndSendMsgRequestHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_CreateAndSendMsgRequestHandler.cs
@@ -21,12 +21,12 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 {
     public class Ping_CreateAndSendMsgRequestHandler : IRequestHandler<Ping_CreateAndSendMsgRequest.V1, Ping.V1.Output>
     {
-        private readonly Func<ICoreDataContext> _coreDataContext;
+        private readonly ICoreDataContextFactory _coreDataContext;
         private readonly IContextProvider<ClaimsPrincipal> _userContext;
         private readonly IBus _bus;
 
         public Ping_CreateAndSendMsgRequestHandler(
-              Func<ICoreDataContext> coreDataContext
+              ICoreDataContextFactory coreDataContext
               , IContextProvider<ClaimsPrincipal> userContext
               , IBus bus
 )
@@ -46,7 +46,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
         public async Task<Ping.V1.Output> ExecuteAsync(Ping_CreateAndSendMsgRequest.V1 request, CancellationToken ctk = default)
         {
-            using var ctx = _coreDataContext();
+            await using var ctx = await _coreDataContext.CreateAsync(ctk);
 
             await ctx.EnsureAudit(AuditKind.Ping, _userContext.GetUserId(), "Create a new Ping", ctk);
 
@@ -72,7 +72,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
             await scope.CompleteAsync();
 
-            ctx.Commit();
+            await ctx.CommitAsync(ctk);
 
             return entity;
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_CreateRequestHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_CreateRequestHandler.cs
@@ -16,11 +16,11 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 {
     public class Ping_CreateRequestHandler : IRequestHandler<Ping_CreateRequest.V1, Ping.V1.Output>
     {
-        private readonly Func<ICoreDataContext> _coreDataContext;
+        private readonly ICoreDataContextFactory _coreDataContext;
         private readonly IContextProvider<ClaimsPrincipal> _userContext;
 
         public Ping_CreateRequestHandler(
-              Func<ICoreDataContext> coreDataContext
+              ICoreDataContextFactory coreDataContext
               , IContextProvider<ClaimsPrincipal> userContext
             )
         {
@@ -38,7 +38,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
         public async Task<Ping.V1.Output> ExecuteAsync(Ping_CreateRequest.V1 request, CancellationToken ctk = default)
         {
-            using var ctx = _coreDataContext();
+            await using var ctx = await _coreDataContext.CreateAsync(ctk);
 
             await ctx.EnsureAudit(AuditKind.Ping, _userContext.GetUserId(), "Create a new Ping", ctk);
 
@@ -53,7 +53,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
             var entity = await ctx.ReadPingByIdAsync(id, ctk);
 
-            ctx.Commit();
+            await ctx.CommitAsync(ctk);
 
             return entity;
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_DeleteRequestHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_DeleteRequestHandler.cs
@@ -16,11 +16,11 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 {
     public class Ping_DeleteRequestHandler : IRequestHandler<Ping_DeleteRequest.V1, bool>
     {
-        private readonly Func<ICoreDataContext> _coreDataContext;
+        private readonly ICoreDataContextFactory _coreDataContext;
         private readonly IContextProvider<ClaimsPrincipal> _userContext;
 
         public Ping_DeleteRequestHandler(
-              Func<ICoreDataContext> coreDataContext
+              ICoreDataContextFactory coreDataContext
               , IContextProvider<ClaimsPrincipal> userContext
             )
         {
@@ -38,7 +38,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
         public async Task<bool> ExecuteAsync(Ping_DeleteRequest.V1 request, CancellationToken ctk = default)
         {
-            using var ctx = _coreDataContext();
+            await using var ctx = await _coreDataContext.CreateAsync(ctk);
 
             var entity = await ctx.ReadPingByIdAsync(request.Id, ctk);
 
@@ -49,7 +49,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
             await ctx.DeletePingAsync(request.Id, ctk);
 
-            ctx.Commit();
+            await ctx.CommitAsync(ctk);
 
             return true;
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_UpdatePatchRequestHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_UpdatePatchRequestHandler.cs
@@ -16,11 +16,11 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 {
     public class Ping_UpdatePatchRequestHandler : IRequestHandler<Ping_UpdatePatchRequest.V1, Ping.V1.Output>
     {
-        private readonly Func<ICoreDataContext> _coreDataContext;
+        private readonly ICoreDataContextFactory _coreDataContext;
         private readonly IContextProvider<ClaimsPrincipal> _userContext;
 
         public Ping_UpdatePatchRequestHandler(
-              Func<ICoreDataContext> coreDataContext
+              ICoreDataContextFactory coreDataContext
               , IContextProvider<ClaimsPrincipal> userContext
             )
         {
@@ -38,7 +38,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
         public async Task<Ping.V1.Output> ExecuteAsync(Ping_UpdatePatchRequest.V1 request, CancellationToken ctk = default)
         {
-            using var ctx = _coreDataContext();
+            await using var ctx = await _coreDataContext.CreateAsync(ctk);
 
             var entity = await ctx.ReadPingByIdAsync(request.Id, ctk);
 
@@ -59,7 +59,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
             entity = await ctx.ReadPingByIdAsync(request.Id, ctk);
 
-            ctx.Commit();
+            await ctx.CommitAsync(ctk);
 
             return entity;
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_UpdatePutRequestHandler.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/Handlers/Requests/Ping_UpdatePutRequestHandler.cs
@@ -16,11 +16,11 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 {
     public class Ping_UpdatePutRequestHandler : IRequestHandler<Ping_UpdatePutRequest.V1, Ping.V1.Output>
     {
-        private readonly Func<ICoreDataContext> _coreDataContext;
+        private readonly ICoreDataContextFactory _coreDataContext;
         private readonly IContextProvider<ClaimsPrincipal> _userContext;
 
         public Ping_UpdatePutRequestHandler(
-              Func<ICoreDataContext> coreDataContext
+              ICoreDataContextFactory coreDataContext
               , IContextProvider<ClaimsPrincipal> userContext
             )
         {
@@ -38,7 +38,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
         public async Task<Ping.V1.Output> ExecuteAsync(Ping_UpdatePutRequest.V1 request, CancellationToken ctk = default)
         {
-            using var ctx = _coreDataContext();
+            await using var ctx = await _coreDataContext.CreateAsync(ctk);
 
             var entity = await ctx.ReadPingByIdAsync(request.Id, ctk);
 
@@ -59,7 +59,7 @@ namespace Ark.Reference.Core.Application.Handlers.Requests
 
             entity = await ctx.ReadPingByIdAsync(request.Id, ctk);
 
-            ctx.Commit();
+            await ctx.CommitAsync(ctk);
 
             return entity;
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/packages.lock.json
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Application/packages.lock.json
@@ -229,8 +229,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w=="
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
       "Microsoft.CodeAnalysis.NetAnalyzers": {
         "type": "Transitive",
@@ -1239,6 +1239,14 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Linq.Async": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
       "System.Linq.Expressions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1847,6 +1855,7 @@
           "Microsoft.CodeAnalysis.NetAnalyzers": "[8.0.0, )",
           "NodaTime": "[3.1.11, )",
           "Polly": "[8.4.1, )",
+          "System.Linq.Async": "[6.0.1, )",
           "System.Reactive": "[6.0.1, )",
           "morelinq": "[4.3.0, )"
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Common/packages.lock.json
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Common/packages.lock.json
@@ -229,8 +229,8 @@
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "1.1.1",
-        "contentHash": "yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w=="
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
       "Microsoft.CodeAnalysis.NetAnalyzers": {
         "type": "Transitive",
@@ -1239,6 +1239,14 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Linq.Async": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
       "System.Linq.Expressions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1835,6 +1843,7 @@
           "Microsoft.CodeAnalysis.NetAnalyzers": "[8.0.0, )",
           "NodaTime": "[3.1.11, )",
           "Polly": "[8.4.1, )",
+          "System.Linq.Async": "[6.0.1, )",
           "System.Reactive": "[6.0.1, )",
           "morelinq": "[4.3.0, )"
         }

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.Tests/Init/DatabaseUtils.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.Tests/Init/DatabaseUtils.cs
@@ -64,7 +64,7 @@ namespace Ark.Reference.Core.Tests.Init
 
         private void _cleanUpEntireDb(bool resetProfileCalendar = false)
         {
-            using (var ctx = new SqlConnection(TestHost.DBConfig.SQLConnectionString))
+            using (var ctx = new SqlConnection(TestHost.DBConfig.ConnectionString))
             {
                 ctx.Open();
                 using (SqlTransaction tx = ctx.BeginTransaction())

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.WebInterface/Utils/RebusProcessorService.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.WebInterface/Utils/RebusProcessorService.cs
@@ -18,7 +18,6 @@ namespace Ark.Reference.Core.WebInterface.Utils
 {
     public sealed class RebusProcessorService : IHostedService, IDisposable
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "Ark.Tools bug")]
         private readonly Container _container;
 
         public RebusProcessorService(IConfiguration config, IServiceProvider services)
@@ -43,8 +42,7 @@ namespace Ark.Reference.Core.WebInterface.Utils
 
         public void Dispose()
         {
-            // BUG: Ark.Tools.Outbox.Rebus has a bug in Disposing in which it hangs
-            // _container?.Dispose();
+            _container?.Dispose();
         }
 
         public Task StartAsync(CancellationToken ctk = default)

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.WebInterface/Utils/RebusProcessorService.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.WebInterface/Utils/RebusProcessorService.cs
@@ -32,7 +32,7 @@ namespace Ark.Reference.Core.WebInterface.Utils
             new ApiHost(cfg)
                 .WithContainer(_container)
                 .WithIClock(services.GetService<IClock>())
-                .WithRebus(Queue.Main,
+                .WithRebus(Queue.Core,
                     services.GetService<InMemNetwork>(),
                     services.GetService<InMemorySubscriberStore>()
                     )

--- a/Ark.ReferenceProject/Core/Ark.Reference.Core.WebInterface/Utils/TransformEmailClaim.cs
+++ b/Ark.ReferenceProject/Core/Ark.Reference.Core.WebInterface/Utils/TransformEmailClaim.cs
@@ -11,27 +11,22 @@ public class TransformEmailClaim : IClaimsTransformation
 
     public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
     {
+        if (principal.HasClaim(c => c.Type == ClaimTypes.Email))
+            return principal;
+
+        // If it does not exist, look for the custom email claim
+        var emailClaim = principal.FindFirst(c => c.Type == "emails");
+        if (emailClaim == null)
+            return principal;
+
         // Clone the current principal to avoid modifying the existing principal directly
         var clone = principal.Clone();
-        var newIdentity = (ClaimsIdentity)clone.Identity;
 
-        // Check if the email claim already exists in the standard format
-        var existingClaim = newIdentity.FindFirst(ClaimTypes.Email);
-        if (existingClaim == null)
-        {
-            // If it does not exist, look for the custom email claim
-            var emailClaim = newIdentity.FindFirst(c => c.Type == "emails");
-            if (emailClaim != null)
-            {
-                // Create a new claim with the standard email claim type
-                var newEmailClaim = new Claim(ClaimTypes.Email, emailClaim.Value);
-
-                // Add the new claim to the cloned identity
-                newIdentity.AddClaim(newEmailClaim);
-            }
-        }
-
-        // Return the modified principal
+        // Create a new claim with the standard email claim type
+        var newEmailClaim = new Claim(ClaimTypes.Email, emailClaim.Value);
+        // Add the new claim to the cloned identity
+        (clone.Identity as ClaimsIdentity)?.AddClaim(newEmailClaim);
         return clone;
+        
     }
 }

--- a/Ark.Tools.Core/IAsyncContext.cs
+++ b/Ark.Tools.Core/IAsyncContext.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
+// Licensed under the MIT License. See LICENSE file for license information. 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Core
+{
+    /// <summary>
+    /// Common definition of transactional 'Context', disposable and committable.
+    /// </summary>
+    public interface IAsyncContext : IAsyncDisposable
+    {
+        Task CommitAsync(CancellationToken ctk = default);
+        Task CommitAsync(bool reuse, CancellationToken ctk = default);
+    }
+}

--- a/Ark.Tools.Core/IAsyncContextFactory.cs
+++ b/Ark.Tools.Core/IAsyncContextFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
+// Licensed under the MIT License. See LICENSE file for license information. 
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Core
+{
+    public interface IAsyncContextFactory<T> where T : IAsyncContext
+    {
+        Task<T> CreateAsync(CancellationToken ctk = default);
+    }
+}

--- a/Ark.Tools.Outbox.Rebus/BusExtensions.cs
+++ b/Ark.Tools.Outbox.Rebus/BusExtensions.cs
@@ -1,22 +1,17 @@
-﻿using Ark.Tools.Core;
-
-using Rebus.Bus;
+﻿using Rebus.Bus;
 using Rebus.Transport;
-
-using System;
-using System.Reactive.Disposables;
 
 namespace Ark.Tools.Outbox.Rebus
 {
     public static class BusExtensions
     {
-        public static RebusTransactionScope Enlist(this RebusTransactionScope tx, IOutboxContext context)
+        public static RebusTransactionScope Enlist(this RebusTransactionScope tx, IOutboxContextCore context)
         {
             tx.TransactionContext.Items.TryAdd(OutboxTransportDecorator._outboxContextItemsKey, context);
             return tx;
         }
 
-        public static RebusTransactionScope Enlist(this IBus bus, IOutboxContext context)
+        public static RebusTransactionScope Enlist(this IBus bus, IOutboxContextCore context)
         {
             var current = AmbientTransactionContext.Current;
             var scope = new RebusTransactionScope();

--- a/Ark.Tools.Outbox.Rebus/Config/RebusOutboxConfigurer.cs
+++ b/Ark.Tools.Outbox.Rebus/Config/RebusOutboxConfigurer.cs
@@ -17,15 +17,6 @@ namespace Ark.Tools.Outbox.Rebus.Config
         public RebusOutboxProcessorConfigurer(StandardConfigurer<ITransport> configurer)
         {
             _configurer = configurer;
-            _configurer.OtherService<IRebusOutboxProcessor>()
-                .Register(s =>
-                {
-                    return new RebusOutboxProcessor(_options.MaxMessagesPerBatch,
-                        s.Get<ITransport>(),
-                        s.Get<IBackoffStrategy>(),
-                        s.Get<IRebusLoggerFactory>(),
-                        s.Get<IOutboxContextFactory>());
-                });
 
             _configurer.Decorate(c =>
             {
@@ -45,7 +36,30 @@ namespace Ark.Tools.Outbox.Rebus.Config
 
         public RebusOutboxProcessorConfigurer OutboxContextFactory(Action<StandardConfigurer<IOutboxContextFactory>> configurer)
         {
+            _configurer.OtherService<IRebusOutboxProcessor>()
+                .Register(s =>
+                {
+                    return new RebusOutboxProcessor(_options.MaxMessagesPerBatch,
+                        s.Get<ITransport>(),
+                        s.Get<IBackoffStrategy>(),
+                        s.Get<IRebusLoggerFactory>(),
+                        s.Get<IOutboxContextFactory>());
+                });
             configurer?.Invoke(_configurer.OtherService<IOutboxContextFactory>());
+            return this;
+        }
+        public RebusOutboxProcessorConfigurer OutboxAsyncContextFactory(Action<StandardConfigurer<IOutboxAsyncContextFactory>> configurer)
+        {
+            _configurer.OtherService<IRebusOutboxProcessor>()
+                .Register(s =>
+                {
+                    return new RebusAsyncOutboxProcessor(_options.MaxMessagesPerBatch,
+                        s.Get<ITransport>(),
+                        s.Get<IBackoffStrategy>(),
+                        s.Get<IRebusLoggerFactory>(),
+                        s.Get<IOutboxAsyncContextFactory>());
+                });
+            configurer?.Invoke(_configurer.OtherService<IOutboxAsyncContextFactory>());
             return this;
         }
 

--- a/Ark.Tools.Outbox.Rebus/OutboxTransportDecorator.cs
+++ b/Ark.Tools.Outbox.Rebus/OutboxTransportDecorator.cs
@@ -38,7 +38,7 @@ namespace Ark.Tools.Outbox.Rebus
         public Task Send(string destinationAddress, TransportMessage message, ITransactionContext context)
         {
             // if there is a IOutboxContext associated with this Send(), batch message and store them on commit
-            var ctx = context.GetOrNull<IOutboxContext>(_outboxContextItemsKey);
+            var ctx = context.GetOrNull<IOutboxContextCore>(_outboxContextItemsKey);
             if (ctx != null)
             {
                 var outgoingMessages = context.GetOrAdd(_outgoingMessagesItemsKey, () =>

--- a/Ark.Tools.Outbox.Rebus/RebusAsyncOutboxProcessor.cs
+++ b/Ark.Tools.Outbox.Rebus/RebusAsyncOutboxProcessor.cs
@@ -1,0 +1,32 @@
+﻿using Rebus.Logging;
+using Rebus.Transport;
+using Rebus.Workers.ThreadPoolBased;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Outbox.Rebus
+{
+    internal sealed class RebusAsyncOutboxProcessor : RebusOutboxProcessorCore
+    {
+        private readonly IOutboxAsyncContextFactory _outboxAsyncContextFactory;
+
+        public RebusAsyncOutboxProcessor(int topMessagesToRetrieve, ITransport transport, IBackoffStrategy backoffStrategy, IRebusLoggerFactory rebusLoggerFactory, IOutboxAsyncContextFactory outboxContextFactory)
+            : base(topMessagesToRetrieve, transport, backoffStrategy, rebusLoggerFactory)
+        {
+            _outboxAsyncContextFactory = outboxContextFactory;
+        }
+
+        protected override async Task<bool> _loop(CancellationToken ctk)
+        {
+            bool waitForMessages = true;
+            await using var ctx = await _outboxAsyncContextFactory.CreateAsync(ctk);
+            
+            waitForMessages = await _tryProcessMessages(ctx, ctk);
+            await ctx.CommitAsync(ctk);
+            
+            return waitForMessages;
+        }
+    }
+}
+

--- a/Ark.Tools.Outbox.Rebus/RebusOutboxProcessor.cs
+++ b/Ark.Tools.Outbox.Rebus/RebusOutboxProcessor.cs
@@ -1,114 +1,34 @@
-﻿using Ark.Tools.Core;
-
-using Rebus.Bus;
-using Rebus.Logging;
-using Rebus.Messages;
+﻿using Rebus.Logging;
 using Rebus.Transport;
 using Rebus.Workers.ThreadPoolBased;
 
-using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ark.Tools.Outbox.Rebus
 {
-    internal sealed class RebusOutboxProcessor : IRebusOutboxProcessor, IDisposable
+
+    internal sealed class RebusOutboxProcessor : RebusOutboxProcessorCore
     {
-		private readonly int _topMessagesToRetrieve;
-		private readonly ITransport _transport;
-		private readonly IBackoffStrategy _backoffStrategy;
         private readonly IOutboxContextFactory _outboxContextFactory;
-        private readonly CancellationTokenSource _busDisposalCancellationTokenSource = new CancellationTokenSource();
-		private readonly ILog _log;
-        private Task _task = Task.CompletedTask;
 
-        public RebusOutboxProcessor(
-			int topMessagesToRetrieve,
-			ITransport transport,
-			IBackoffStrategy backoffStrategy,
-			IRebusLoggerFactory rebusLoggerFactory,
-			IOutboxContextFactory outboxContextFactory)
-		{
-			_topMessagesToRetrieve = topMessagesToRetrieve;
-			_transport = transport;
-			_backoffStrategy = backoffStrategy;
-			_outboxContextFactory = outboxContextFactory;
-			_log = rebusLoggerFactory.GetLogger<RebusOutboxProcessor>();
-		}
-
-        public void Dispose()
+        public RebusOutboxProcessor(int topMessagesToRetrieve, ITransport transport, IBackoffStrategy backoffStrategy, IRebusLoggerFactory rebusLoggerFactory, IOutboxContextFactory outboxContextFactory) 
+            : base(topMessagesToRetrieve, transport, backoffStrategy, rebusLoggerFactory)
         {
-            _busDisposalCancellationTokenSource?.Dispose();
+            _outboxContextFactory = outboxContextFactory;
         }
 
-        public void Start()
+        protected override async Task<bool> _loop(CancellationToken ctk)
         {
-			_task = _processOutboxMessages(_busDisposalCancellationTokenSource.Token);
-		}
+            bool waitForMessages = true;
+            using (var ctx = _outboxContextFactory.Create())
+            {
+                waitForMessages = await _tryProcessMessages(ctx, ctk);
+                ctx.Commit();
+            }
 
-        public void Stop()
-        {
-			_busDisposalCancellationTokenSource.Dispose();
-			_task.GetAwaiter().GetResult(); // wait for batch to complete
-		}
-
-        private async Task _processOutboxMessages(CancellationToken ctk)
-		{
-			_log.Debug("Starting outbox messages processor");
-
-			while (!ctk.IsCancellationRequested)
-			{
-				try
-				{
-					bool waitForMessages = true;
-					using (var ctx = _outboxContextFactory.Create())
-					{
-						var messages = await ctx.PeekLockMessagesAsync(_topMessagesToRetrieve, ctk);
-						if (messages.Any())
-						{
-							using (var rebusTransactionScope = new RebusTransactionScope())
-							{
-								foreach (var message in messages)
-								{
-									var destinationAddress = message?.Headers?[OutboxTransportDecorator._outboxRecepientHeader];
-									message?.Headers?.Remove(OutboxTransportDecorator._outboxRecepientHeader);
-									await _transport.Send(destinationAddress!, new TransportMessage(message?.Headers, message?.Body),
-										rebusTransactionScope.TransactionContext).WithCancellation(ctk);
-								}
-								await rebusTransactionScope.CompleteAsync().WithCancellation(ctk);
-							}
-							waitForMessages = false;
-							_backoffStrategy.Reset();
-						}
-						ctx.Commit();
-					}
-
-					if (waitForMessages)
-					{
-						await _backoffStrategy.WaitNoMessageAsync(ctk);
-					}
-				}
-				catch (OperationCanceledException) when (ctk.IsCancellationRequested)
-				{
-					// we're shutting down
-				}
-				catch (Exception exception)
-				{
-					_log.Error(exception, "Unhandled exception in outbox messages processor");
-                    try
-                    {
-                        await _backoffStrategy.WaitErrorAsync(ctk);
-                    }
-                    catch (OperationCanceledException) when (ctk.IsCancellationRequested)
-                    {
-                        // we're shutting down
-                    }
-                }
-			}
-
-			_log.Debug("Outbox messages processor stopped");
-		}
-	}
+            return waitForMessages;
+        }
+    }
 }
 

--- a/Ark.Tools.Outbox.Rebus/RebusOutboxProcessorCore.cs
+++ b/Ark.Tools.Outbox.Rebus/RebusOutboxProcessorCore.cs
@@ -41,7 +41,7 @@ namespace Ark.Tools.Outbox.Rebus
 
         public void Stop()
         {
-			_busDisposalCancellationTokenSource.Dispose();
+            _busDisposalCancellationTokenSource.Cancel();
 			_task.GetAwaiter().GetResult(); // wait for batch to complete
 		}
 

--- a/Ark.Tools.Outbox.Rebus/RebusOutboxProcessorCore.cs
+++ b/Ark.Tools.Outbox.Rebus/RebusOutboxProcessorCore.cs
@@ -1,0 +1,134 @@
+﻿using Ark.Tools.Core;
+
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Transport;
+using Rebus.Workers.ThreadPoolBased;
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Outbox.Rebus
+{
+    internal abstract class RebusOutboxProcessorCore : IRebusOutboxProcessor, IDisposable
+    {
+		private readonly IBackoffStrategy _backoffStrategy;
+        private readonly int _topMessagesToRetrieve;
+        private readonly ITransport _transport;
+        private readonly CancellationTokenSource _busDisposalCancellationTokenSource = new CancellationTokenSource();
+		private readonly ILog _log;
+        private Task _task = Task.CompletedTask;
+        private bool _disposedValue;
+
+        protected RebusOutboxProcessorCore(
+            int topMessagesToRetrieve, 
+            ITransport transport,
+            IBackoffStrategy backoffStrategy,
+			IRebusLoggerFactory rebusLoggerFactory)
+		{
+			_backoffStrategy = backoffStrategy;
+            _topMessagesToRetrieve = topMessagesToRetrieve;
+            _transport = transport;
+            _log = rebusLoggerFactory.GetLogger<RebusOutboxProcessorCore>();
+		}
+
+        public void Start()
+        {
+			_task = _processOutboxMessages(_busDisposalCancellationTokenSource.Token);
+		}
+
+        public void Stop()
+        {
+			_busDisposalCancellationTokenSource.Dispose();
+			_task.GetAwaiter().GetResult(); // wait for batch to complete
+		}
+
+        protected async Task<bool> _tryProcessMessages(IOutboxContextCore ctx, CancellationToken ctk)
+        {
+            bool waitForMessages = true;
+            var messages = await ctx.PeekLockMessagesAsync(_topMessagesToRetrieve, ctk);
+            if (messages.Any())
+            {
+                using (var rebusTransactionScope = new RebusTransactionScope())
+                {
+                    foreach (var message in messages)
+                    {
+                        var destinationAddress = message?.Headers?[OutboxTransportDecorator._outboxRecepientHeader];
+                        message?.Headers?.Remove(OutboxTransportDecorator._outboxRecepientHeader);
+                        await _transport.Send(destinationAddress!, new TransportMessage(message?.Headers, message?.Body),
+                            rebusTransactionScope.TransactionContext).WithCancellation(ctk);
+                    }
+                    await rebusTransactionScope.CompleteAsync().WithCancellation(ctk);
+                }
+                waitForMessages = false;
+            }
+
+            return waitForMessages;
+        }
+
+        private async Task _processOutboxMessages(CancellationToken ctk)
+		{
+			_log.Debug("Starting outbox messages processor");
+
+			while (!ctk.IsCancellationRequested)
+			{
+				try
+                {
+                    bool waitForMessages = await _loop(ctk);
+
+                    if (waitForMessages)
+                    {
+                        await _backoffStrategy.WaitNoMessageAsync(ctk);
+                    } else
+                    {
+                        _backoffStrategy.Reset();
+                    }
+                }
+                catch (OperationCanceledException) when (ctk.IsCancellationRequested)
+				{
+					// we're shutting down
+				}
+				catch (Exception exception)
+				{
+					_log.Error(exception, "Unhandled exception in outbox messages processor");
+                    try
+                    {
+                        await _backoffStrategy.WaitErrorAsync(ctk);
+                    }
+                    catch (OperationCanceledException) when (ctk.IsCancellationRequested)
+                    {
+                        // we're shutting down
+                    }
+                }
+			}
+
+			_log.Debug("Outbox messages processor stopped");
+		}
+
+        protected abstract Task<bool> _loop(CancellationToken ctk);
+
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _busDisposalCancellationTokenSource?.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}
+

--- a/Ark.Tools.Outbox.SqlServer/AbstractSqlAsyncContextWithOutbox.cs
+++ b/Ark.Tools.Outbox.SqlServer/AbstractSqlAsyncContextWithOutbox.cs
@@ -1,21 +1,20 @@
 ﻿using Ark.Tools.Sql;
 
 using System.Collections.Generic;
-using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ark.Tools.Outbox.SqlServer
 {
-    public abstract class AbstractSqlContextWithOutbox<Tag> : AbstractSqlContext<Tag>, IOutboxContext
+    public abstract class AbstractSqlAsyncContextWithOutbox<Tag> : AbstractSqlAsyncContext<Tag>, IOutboxAsyncContext
     {
-        private readonly OutboxContextSql<Tag> _outbox;
+        private readonly OutboxAsyncContextSql<Tag> _outbox;
 
-        protected AbstractSqlContextWithOutbox(DbConnection connection, IOutboxContextSqlConfig config, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted) 
-            : base(connection, isolationLevel)
+        protected AbstractSqlAsyncContextWithOutbox(DbTransaction transaction, IOutboxContextSqlConfig config)
+            : base(transaction)
         {
-            _outbox = new OutboxContextSql<Tag>(this, config);
+            _outbox = new OutboxAsyncContextSql<Tag>(this, config);
         }
 
         public Task ClearAsync(CancellationToken ctk = default)
@@ -37,5 +36,6 @@ namespace Ark.Tools.Outbox.SqlServer
         {
             return _outbox.SendAsync(messages, ctk);
         }
+
     }
 }

--- a/Ark.Tools.Outbox.SqlServer/HeaderSerializer.cs
+++ b/Ark.Tools.Outbox.SqlServer/HeaderSerializer.cs
@@ -1,20 +1,6 @@
-﻿using Ark.Tools.Sql;
-
-using Dapper;
-
-using MoreLinq;
-
-using NLog;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Data.Common;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Text.Json;
-using System.Text;
 
 namespace Ark.Tools.Outbox.SqlServer
 {

--- a/Ark.Tools.Outbox.SqlServer/OutboxAsyncContextSql.cs
+++ b/Ark.Tools.Outbox.SqlServer/OutboxAsyncContextSql.cs
@@ -4,12 +4,11 @@ using System.Data;
 
 namespace Ark.Tools.Outbox.SqlServer
 {
-
-    internal sealed class OutboxContextSql<Tag> : OutboxContextSqlCore
+    internal sealed class OutboxAsyncContextSql<Tag> : OutboxContextSqlCore
     {
-        private readonly ISqlContext<Tag> _context;
+        private readonly ISqlAsyncContext<Tag> _context;
 
-        public OutboxContextSql(ISqlContext<Tag> context, IOutboxContextSqlConfig config) : base(config)
+        public OutboxAsyncContextSql(ISqlAsyncContext<Tag> context, IOutboxContextSqlConfig config) : base(config)
         {
             _context = context;
         }

--- a/Ark.Tools.Outbox.SqlServer/OutboxContextSqlCore.cs
+++ b/Ark.Tools.Outbox.SqlServer/OutboxContextSqlCore.cs
@@ -1,0 +1,150 @@
+﻿using Dapper;
+
+using MoreLinq;
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Outbox.SqlServer
+{
+    internal abstract class OutboxContextSqlCore
+    {
+        private readonly IOutboxContextSqlConfig _config;
+        private readonly Statements _statements;
+
+        private static readonly HeaderSerializer _headerSerializer = new HeaderSerializer();
+
+        public OutboxContextSqlCore(IOutboxContextSqlConfig config)
+        {
+            _config = config;
+            _statements = new Statements(config);
+        }
+
+        protected abstract IDbTransaction _transaction { get; }
+        protected abstract IDbConnection _connection { get; }
+
+        class Statements
+        {
+            internal Statements(IOutboxContextSqlConfig config)
+            {
+                var schema = config.SchemaName ?? "dbo";
+                var table = config.TableName;
+                var full = $"[{schema}].[{table}]";
+                Insert = $@"
+                    INSERT INTO {full}
+                    (
+                          [Headers]
+                        , [Body]
+                    )
+                    VALUES
+                    (
+                          @pHeaders
+                        , @pBody
+                    )
+                    ";
+
+                PeekLock = (int messageCount) => $@"
+                    ;WITH batch AS (
+                        SELECT TOP ({messageCount}) *
+                        FROM {full}
+                        ORDER BY Id DESC)
+                    DELETE FROM batch
+                    WITH (READPAST, ROWLOCK, READCOMMITTEDLOCK)
+                    OUTPUT
+                          DELETED.[Headers]
+                        , DELETED.[Body]
+                    ";
+
+                Count = $@"
+                    SELECT COUNT(*) as [Count] 
+                    FROM {full}
+                    ";
+
+                Clear = $@"
+                    DELETE FROM {full}
+                    ";
+
+                CreateTable = $@"
+                    IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '{schema}')
+                    BEGIN
+	                    EXEC('CREATE SCHEMA {schema}')
+                    END
+
+                    IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{schema}' AND TABLE_NAME = '{table}')
+                        CREATE TABLE {full} (
+                            [Id] [bigint] IDENTITY(1,1) NOT NULL,
+	                        [Headers] [nvarchar](MAX) NOT NULL,
+	                        [Body] [varbinary](MAX) NOT NULL,
+                            CONSTRAINT [PK_{table}] PRIMARY KEY CLUSTERED 
+                            (
+	                            [Id] ASC
+                            )
+                        )
+  
+                    ";
+                
+            }
+
+            public string Insert { get; }
+            public Func<int, string> PeekLock { get; }
+            public string Count { get; }
+            public string Clear { get; }
+            public string CreateTable { get; }
+        }
+
+        public async Task SendAsync(IEnumerable<OutboxMessage> messages, CancellationToken ctk = default)
+        {
+            foreach (var b in messages.Batch(1000))
+            {
+                var parameters = b.Select(message => new
+                {
+                    pHeaders = _headerSerializer.SerializeToString(message.Headers),
+                    pBody = message.Body
+                });
+
+                var cmd = new CommandDefinition(_statements.Insert, parameters, transaction: _transaction, cancellationToken: ctk);
+
+                _ = await _connection.ExecuteAsync(cmd);
+            }
+        }
+
+        public async Task<IEnumerable<OutboxMessage>> PeekLockMessagesAsync(int messageCount = 10, CancellationToken ctk = default)
+        {
+            var cmd = new CommandDefinition(_statements.PeekLock(messageCount), transaction: _transaction, cancellationToken: ctk);
+
+            var res = await _connection.QueryAsync<(string Headers, byte[] Body)>(cmd);
+
+            return res.Select(x => new OutboxMessage
+            {
+                Body = x.Body,
+                Headers = _headerSerializer.DeserializeFromString(x.Headers)
+            }).ToList();
+        }
+
+        public Task<int> CountAsync(CancellationToken ctk = default)
+        {
+            var cmd = new CommandDefinition(_statements.Count, transaction: _transaction, cancellationToken: ctk);
+
+            return _connection.QuerySingleAsync<int>(cmd);
+        }
+
+        public Task ClearAsync(CancellationToken ctk = default)
+        {
+            var cmd = new CommandDefinition(_statements.Clear, transaction: _transaction, cancellationToken: ctk);
+
+            return _connection.ExecuteAsync(cmd);
+        }
+
+        public Task EnsureTableAreCreated(CancellationToken ctk = default)
+        {
+            var cmd = new CommandDefinition(_statements.CreateTable, transaction: _transaction, cancellationToken: ctk);
+
+            return _connection.ExecuteAsync(cmd);
+        }
+
+    }
+}

--- a/Ark.Tools.Outbox/IOutboxAsyncContext.cs
+++ b/Ark.Tools.Outbox/IOutboxAsyncContext.cs
@@ -1,0 +1,6 @@
+﻿using Ark.Tools.Core;
+
+namespace Ark.Tools.Outbox
+{
+    public interface IOutboxAsyncContext: IOutboxContextCore, IAsyncContext { }
+}

--- a/Ark.Tools.Outbox/IOutboxAsyncContextFactory.cs
+++ b/Ark.Tools.Outbox/IOutboxAsyncContextFactory.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Outbox
+{
+    public interface IOutboxAsyncContextFactory
+    {
+        Task<IOutboxAsyncContext> CreateAsync(CancellationToken ctk = default);
+    }
+}

--- a/Ark.Tools.Outbox/IOutboxContext.cs
+++ b/Ark.Tools.Outbox/IOutboxContext.cs
@@ -1,62 +1,7 @@
 ﻿using Ark.Tools.Core;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Ark.Tools.Outbox
 {
-    /// <summary>
-    /// Context extension interface for Outbox pattern to enlist in an existing Context
-    /// </summary>
-    /// <remarks>
-    /// A given Context must be estended with this interface to be then used by the Producer to send messages in the same transaction of another Context.
-    /// </remarks>
-    public interface IOutboxContext : IContext
-    {
-        /// <summary>
-        /// Store messages to the Outbox to be then Sent via Processor to the broker
-        /// </summary>
-        /// <remarks>
-        /// The message will then be routed by the OutboxProcessor broker to the destination.
-        /// </remarks>
-        /// <param name="messages"></param>
-        /// <param name="ctk"></param>
-        Task SendAsync(
-              IEnumerable<OutboxMessage> messages
-            , CancellationToken ctk = default
-        );
 
-        /// <summary>
-        /// Peek-lock a batch of messages
-        /// </summary>
-        /// <remarks>Messages will be deleted con <see cref="IContext.Commit()"/>.</remarks>
-        /// <param name="messageCount"></param>
-        /// <param name="ctk"></param>
-        /// <returns>A batch of messages.</returns>
-        Task<IEnumerable<OutboxMessage>> PeekLockMessagesAsync(
-               int messageCount = 10
-             , CancellationToken ctk = default
-        );
-
-        /// <summary>
-        /// Counts the number of non-locked messages in the Outbox
-        /// </summary>
-        /// <param name="ctk"></param>
-        /// <returns>The count of messages in the Outbox.</returns>
-        Task<int> CountAsync(
-            CancellationToken ctk = default
-        );
-
-        /// <summary>
-        /// Delete all pending message in the Outbox
-        /// </summary>
-        /// <param name="ctk"></param>
-        Task ClearAsync(
-            CancellationToken ctk = default
-        );
-    }
+    public interface IOutboxContext : IOutboxContextCore, IContext { }
 }

--- a/Ark.Tools.Outbox/IOutboxContextCore.cs
+++ b/Ark.Tools.Outbox/IOutboxContextCore.cs
@@ -1,0 +1,59 @@
+﻿using Ark.Tools.Core;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Outbox
+{
+    /// <summary>
+    /// Context extension interface for Outbox pattern to enlist in an existing Context
+    /// </summary>
+    /// <remarks>
+    /// A given Context must be estended with this interface to be then used by the Producer to send messages in the same transaction of another Context.
+    /// </remarks>
+    public interface IOutboxContextCore
+    {
+        /// <summary>
+        /// Store messages to the Outbox to be then Sent via Processor to the broker
+        /// </summary>
+        /// <remarks>
+        /// The message will then be routed by the OutboxProcessor broker to the destination.
+        /// </remarks>
+        /// <param name="messages"></param>
+        /// <param name="ctk"></param>
+        Task SendAsync(
+              IEnumerable<OutboxMessage> messages
+            , CancellationToken ctk = default
+        );
+
+        /// <summary>
+        /// Peek-lock a batch of messages
+        /// </summary>
+        /// <remarks>Messages will be deleted on <see cref="IContext.Commit()"/>.</remarks>
+        /// <param name="messageCount"></param>
+        /// <param name="ctk"></param>
+        /// <returns>A batch of messages.</returns>
+        Task<IEnumerable<OutboxMessage>> PeekLockMessagesAsync(
+               int messageCount = 10
+             , CancellationToken ctk = default
+        );
+
+        /// <summary>
+        /// Counts the number of non-locked messages in the Outbox
+        /// </summary>
+        /// <param name="ctk"></param>
+        /// <returns>The count of messages in the Outbox.</returns>
+        Task<int> CountAsync(
+            CancellationToken ctk = default
+        );
+
+        /// <summary>
+        /// Delete all pending message in the Outbox
+        /// </summary>
+        /// <param name="ctk"></param>
+        Task ClearAsync(
+            CancellationToken ctk = default
+        );
+    }
+}

--- a/Ark.Tools.Outbox/IOutboxContextFactory.cs
+++ b/Ark.Tools.Outbox/IOutboxContextFactory.cs
@@ -1,13 +1,4 @@
-﻿using Ark.Tools.Core;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Ark.Tools.Outbox
+﻿namespace Ark.Tools.Outbox
 {
 
     public interface IOutboxContextFactory

--- a/Ark.Tools.Sql.SqlServer/ReliableSqlConnectionManager.cs
+++ b/Ark.Tools.Sql.SqlServer/ReliableSqlConnectionManager.cs
@@ -3,9 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using Dapper;
 
-using System.Threading.Tasks;
+using Ark.Tools.Core;
 
 using Microsoft.Data.SqlClient;
 

--- a/Ark.Tools.Sql/AbstractSqlAsyncContext.cs
+++ b/Ark.Tools.Sql/AbstractSqlAsyncContext.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
+// Licensed under the MIT License. See LICENSE file for license information. 
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Sql
+{
+    public abstract class AbstractSqlAsyncContext<Tag> : ISqlAsyncContext<Tag>, IDisposable
+    {
+        private DbConnection? _connection;
+        private DbTransaction? _transaction;
+        private IsolationLevel _isolationLevel;
+
+        protected AbstractSqlAsyncContext(DbTransaction transaction)
+        {
+            _transaction = transaction;
+            _connection = transaction.Connection!;
+            _isolationLevel = transaction.IsolationLevel;
+        }
+
+        public DbConnection Connection
+        {
+            get
+            {
+                return _connection ?? throw new InvalidProgramException("There's no connection");
+            }
+        }
+
+        public DbTransaction Transaction
+        {
+            get
+            {
+                return _transaction ?? throw new InvalidProgramException("There's no transaction. Use CommitAsync(true,ctk) if you want to reuse a Context. Prefer to use a new instance.");
+            }
+        }
+
+        public Task CommitAsync(CancellationToken ctk = default)
+        {
+            return CommitAsync(false, ctk);
+        }
+
+        public virtual async Task CommitAsync(bool reuse, CancellationToken ctk = default)
+        {
+            if (_transaction != null)
+            {
+                await _transaction.CommitAsync(ctk);
+                await _transaction.DisposeAsync();
+            }
+            _transaction = null;
+
+            if (reuse)
+            {
+                _transaction = await _connection!.BeginTransactionAsync(_isolationLevel, ctk);
+            }
+        }
+
+        public virtual async Task ChangeIsolationLevelAsync(IsolationLevel isolationLevel, CancellationToken ctk = default)
+        {
+            _isolationLevel = isolationLevel;
+            await RollbackAsync(ctk);
+        }
+
+        public virtual async Task RollbackAsync(CancellationToken ctk = default)
+        {
+            if (_transaction != null)
+            {
+                await _transaction.RollbackAsync(ctk);
+                await _transaction.DisposeAsync();
+            }
+
+            _transaction = null;
+        }
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore().ConfigureAwait(false);
+
+            Dispose(disposing: false);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_transaction is not null)
+                {
+                    _transaction.Dispose();
+                    _transaction = null;
+                }
+
+                if (_connection is not null)
+                {
+                    _connection.Dispose();
+                    _connection = null;
+                }
+            }
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (_transaction is not null)
+            {
+                await _transaction.DisposeAsync().ConfigureAwait(false);
+            }
+            _transaction = null;
+
+            if (_connection is not null)
+            {
+                await _connection.DisposeAsync().ConfigureAwait(false);
+            }
+            _connection = null;
+        }
+
+    }
+}

--- a/Ark.Tools.Sql/AbstractSqlAsyncContextFactory.cs
+++ b/Ark.Tools.Sql/AbstractSqlAsyncContextFactory.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
+// Licensed under the MIT License. See LICENSE file for license information. 
+using Ark.Tools.Core;
+
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Sql
+{
+    public abstract class AbstractSqlAsyncContextFactory<TContext, Tag> : IAsyncContextFactory<TContext> where TContext : ISqlAsyncContext<Tag>
+    {
+        private readonly IDbConnectionManager _connectionManager;
+        private readonly ISqlContextConfig _config;
+
+        public AbstractSqlAsyncContextFactory(IDbConnectionManager connectionManager, ISqlContextConfig config)
+        {
+            _connectionManager = connectionManager;
+            _config = config;
+        }
+
+        public virtual async Task<TContext> CreateAsync(CancellationToken ctk = default)
+        {
+            DbConnection? connection = null;
+            DbTransaction? transaction = null;
+            var il = _config.IsolationLevel;
+            try
+            {
+
+                connection = await _connectionManager.GetAsync(_config.ConnectionString, ctk);
+
+                if (connection.State == ConnectionState.Closed)
+                    await connection.OpenAsync(ctk);
+
+                if (il is not null)
+                    transaction = await connection.BeginTransactionAsync(il.Value, ctk);
+                else
+                    transaction = await connection.BeginTransactionAsync(ctk);
+
+                return CreateContext(transaction);
+            }
+            catch
+            {
+                if (transaction != null)
+                {
+                    await transaction.DisposeAsync();
+                }
+                if (connection != null)
+                {
+                    await connection.DisposeAsync();
+                }
+                throw;
+            }
+        }
+
+        protected abstract TContext CreateContext(DbTransaction transaction);
+    }
+}

--- a/Ark.Tools.Sql/IDbConnectionManager.cs
+++ b/Ark.Tools.Sql/IDbConnectionManager.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
 // Licensed under the MIT License. See LICENSE file for license information. 
-using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Ark.Tools.Sql/ISqlAsyncContext.cs
+++ b/Ark.Tools.Sql/ISqlAsyncContext.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
+// Licensed under the MIT License. See LICENSE file for license information. 
+using Ark.Tools.Core;
+
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ark.Tools.Sql
+{
+    public interface ISqlAsyncContext<Tag> : IAsyncContext
+    {
+        DbConnection Connection { get; }
+        DbTransaction Transaction { get; }
+        Task RollbackAsync(CancellationToken ctk = default);
+        Task ChangeIsolationLevelAsync(IsolationLevel isolationLevel, CancellationToken ctk = default);
+    }
+}

--- a/Ark.Tools.Sql/ISqlContext.cs
+++ b/Ark.Tools.Sql/ISqlContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
 // Licensed under the MIT License. See LICENSE file for license information. 
 using Ark.Tools.Core;
+
 using System.Data;
 using System.Data.Common;
 

--- a/Ark.Tools.Sql/ISqlContextConfig.cs
+++ b/Ark.Tools.Sql/ISqlContextConfig.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (C) 2024 Ark Energy S.r.l. All rights reserved.
+// Licensed under the MIT License. See LICENSE file for license information. 
+using System.Data;
+
+namespace Ark.Tools.Sql
+{
+    public interface ISqlContextConfig
+    {
+        string ConnectionString { get; }
+        IsolationLevel? IsolationLevel { get; }
+    }
+}

--- a/Ark.Tools.sln
+++ b/Ark.Tools.sln
@@ -74,6 +74,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Ark.Tools.sln.licenseheader = Ark.Tools.sln.licenseheader
 		Directory.Build.props = Directory.Build.props
+		.devcontainer\docker-compose.yml = .devcontainer\docker-compose.yml
 		global.json = global.json
 		Group_Pack_All.bat = Group_Pack_All.bat
 		Group_Pack_AspnetCore.bat = Group_Pack_AspnetCore.bat


### PR DESCRIPTION
Support OpenAsync and BeginTransactionAsync when using Sql Contexts.

Instead of `using var ctx = _ctx()` now is possible to do `await using var ctx = await _ctxFactory.CreateAsync(ctk)`.

