### PR TITLE
fix(NLog): revert to use NLog internal JsonSerializer

### DIFF
--- a/Ark.Tools.NLog.Configuration/NLogConfigurer.Configuration.cs
+++ b/Ark.Tools.NLog.Configuration/NLogConfigurer.Configuration.cs
@@ -83,7 +83,8 @@ namespace Ark.Tools.NLog
             return builder.ConfigureLogging((ctx, logging) =>
             {
                 var c = NLogConfigurer.For(appName)
-                   .WithDefaultTargetsAndRulesFromConfiguration(ctx.Configuration, appName, mailFrom, async: !ctx.HostingEnvironment.IsEnvironment("SpecFlow"))                   
+                   .WithDefaultTargetsAndRulesFromConfiguration(ctx.Configuration, appName, mailFrom, 
+                        async: !ctx.HostingEnvironment.EnvironmentName.Contains("SpecFlow", StringComparison.OrdinalIgnoreCase))
                    ;
 
                 configure ?.Invoke(c);


### PR DESCRIPTION
The NLog internal json serializer do not support types that STJ does, thus seemed smart to use STJ. But STJ doesn't fallback to Convert.ToString() for unsupported types (e.g. Type).

Instead in Logging is common to expect the logging parameters by using ToString() / Convert.ToString() and by extension also when serializing the Structured Logging json.

Revert to Default Json serializer until a better option is devised, e.g. by agumenting the STJ to fallback to string for unsupported types.