### PR TITLE
sdk: align var and whitespace configuration

### DIFF
--- a/src/sdk/Ark.Tools.Build/configuration/coding-style/Ark.Tools.CodingStyle.editorconfig
+++ b/src/sdk/Ark.Tools.Build/configuration/coding-style/Ark.Tools.CodingStyle.editorconfig
@@ -70,9 +70,9 @@ dotnet_style_namespace_match_folder = true:suggestion
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = true
-csharp_style_var_for_built_in_types = true
-csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = true:silent
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:silent

--- a/src/sdk/Ark.Tools.Build/configuration/coding-style/Ark.Tools.CodingStyle.editorconfig
+++ b/src/sdk/Ark.Tools.Build/configuration/coding-style/Ark.Tools.CodingStyle.editorconfig
@@ -12,6 +12,7 @@ tab_width = 4
 # New line preferences
 end_of_line = crlf
 insert_final_newline = false
+trim_trailing_whitespace = true
 
 #### .NET Coding Conventions ####
 
@@ -69,9 +70,9 @@ dotnet_style_namespace_match_folder = true:suggestion
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = false:silent
-csharp_style_var_for_built_in_types = false:silent
-csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = true
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:silent


### PR DESCRIPTION
## Summary
- align Ark.Tools.Build var preferences with Meziantou by enabling `var` for built-in types, apparent types, and elsewhere
- enable trailing-whitespace trimming in the packaged editorconfig
- retain the existing `MA0015.consider_member_access_as_parameter = true` setting in the packaged Meziantou analyzer globalconfig

## Validation
- `dotnet build --no-restore` passed
- `dotnet pack src/sdk/Ark.Tools.Build/Ark.Tools.Build.csproj --no-restore` passed and included both configuration files
- `dotnet test --no-build` attempted; integration tests failed on the local Service Bus emulator returning HTTP 500